### PR TITLE
Add slim style

### DIFF
--- a/style/README.md
+++ b/style/README.md
@@ -15,6 +15,7 @@ detailed, language/framework-specific style guides:
 * [Ruby](ruby)
 * [Sass](sass)
 * [Shell](shell)
+* [Slim](slim)
 * [Testing](testing)
 
 Formatting

--- a/style/slim/README.md
+++ b/style/slim/README.md
@@ -1,0 +1,12 @@
+# Slim
+
+## Formatting
+
+* Use the following slim syntax:
+```
+div class="my_class" id="my_id"
+```
+and not:
+```
+.my_class#my_id
+```


### PR DESCRIPTION
Reason:
* Easier to read
* Easier to understand for a frontend developer who has not knowledge in ruby
* This syntax works in all case:
```slim
div class="left #{my_awesome_class}"
```
compare to
```slim
class#mon-id *{class: ["ma class ruby"]}
```

It is what you can find in the doc:
```slim
.first *{class: [:second, :third]} Text
```
And it is not really readable compare to:
```slim
div class="first #{second} #{third}" Text
```